### PR TITLE
refactor(commonmodels): Align error handling

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
           go-version: '1.25.0'
 
       - name: Install golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v8
         with:
           version: latest
 

--- a/commonmodels/core/core.go
+++ b/commonmodels/core/core.go
@@ -55,7 +55,7 @@ type CoreModel struct {
 //
 // Call this after defaults have been applied (e.g., after Create/Touch or
 // after GORM hooks). It returns nil if the model is valid.
-func (b *CoreModel) Validate(loc string, code string) []verr.ValidationError {
+func (b *CoreModel) ValidateWithContext(loc string, code string) []verr.ValidationError {
 	var errs []verr.ValidationError
 
 	// local function helper creating and appending errors.
@@ -106,6 +106,10 @@ func (b *CoreModel) Validate(loc string, code string) []verr.ValidationError {
 	}
 
 	return errs
+}
+
+func (b *CoreModel) Validate() []verr.ValidationError {
+	return b.ValidateWithContext("", "")
 }
 
 // Create applies create-time defaults and audit fields to Core model.

--- a/commonmodels/core/core.go
+++ b/commonmodels/core/core.go
@@ -4,12 +4,12 @@
 package core
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 
+	errC "github.com/grasp-labs/ds-go-commonmodels/v2/commonmodels/enum/errors"
 	status "github.com/grasp-labs/ds-go-commonmodels/v2/commonmodels/enum/status"
 	types "github.com/grasp-labs/ds-go-commonmodels/v2/commonmodels/types"
 	verr "github.com/grasp-labs/ds-go-commonmodels/v2/commonmodels/validation_error"
@@ -55,61 +55,64 @@ type CoreModel struct {
 //
 // Call this after defaults have been applied (e.g., after Create/Touch or
 // after GORM hooks). It returns nil if the model is valid.
-func (b *CoreModel) ValidateWithContext(loc string, code string) []verr.ValidationError {
+func (b *CoreModel) ValidateWithContext(loc string, code string, locale string) []verr.ValidationError {
+	if locale == "" {
+		locale = "en"
+	}
 	var errs []verr.ValidationError
 
 	// local function helper creating and appending errors.
-	req := func(field, msg string) {
+	req := func(field, code string) {
+		msg := errC.HumanMessageLocale(locale, code, field)
 		errs = append(errs, verr.ValidationError{Field: field, Message: msg, Loc: loc, Code: code})
 	}
-
 	if b.ID == uuid.Nil {
-		req("id", "required")
+		req("id", errC.Required)
 	}
 	if b.TenantID == uuid.Nil {
-		req("tenant_id", "required")
+		req("tenant_id", errC.Required)
 	}
 	if b.Name == "" {
-		req("name", "required")
+		req("name", errC.Required)
 	}
 	if b.CreatedBy == "" {
-		req("created_by", "required")
+		req("created_by", errC.Required)
 	}
 	if !email.IsEmailFormat(b.CreatedBy) {
-		req("created_by", "not a valid email format")
+		req("created_by", errC.InvalidEmailFormat)
 	}
 	if b.ModifiedBy == "" {
-		req("modified_by", "required")
+		req("modified_by", errC.Required)
 	}
 	if !email.IsEmailFormat(b.ModifiedBy) {
-		req("modified_by", "not a valid email format")
+		req("modified_by", errC.InvalidEmailFormat)
 	}
 	if b.CreatedAt.IsZero() {
-		req("created_at", "required")
+		req("created_at", errC.Required)
 	}
 	if b.ModifiedAt.IsZero() {
-		req("modified_at", "required")
+		req("modified_at", errC.Required)
 	}
 
 	switch b.Status {
 	case status.Active, status.Deleted, status.Suspended, status.Rejected, status.Draft:
 		// ok
 	default:
-		req("status", fmt.Sprintf("invalid %q; expected one of active, deleted, suspended, rejected, draft", b.Status))
+		req("status", errC.InvalidStatus)
 	}
 
 	if err := b.Metadata.Validate(); err != nil {
-		req("metadata", "invalid JSON structure")
+		req("metadata", errC.InvalidJSONFormat)
 	}
 	if err := b.Tags.Validate(); err != nil {
-		req("tags", "invalid JSON structure")
+		req("tags", errC.InvalidJSONFormat)
 	}
 
 	return errs
 }
 
 func (b *CoreModel) Validate() []verr.ValidationError {
-	return b.ValidateWithContext("", "")
+	return b.ValidateWithContext("body", "", "en")
 }
 
 // Create applies create-time defaults and audit fields to Core model.

--- a/commonmodels/core/core.go
+++ b/commonmodels/core/core.go
@@ -26,10 +26,6 @@ import (
 //	defer func() { Now = old }()
 var Now = func() time.Time { return time.Now().UTC() }
 
-// ValidationErrors is a collection of field-level validation errors.
-// The element type ValidationError is defined in errors.go.
-type ValidationErrors []verr.ValidationError
-
 // BaseModel defines a common set of fields shared by persisted entities.
 // Embed this type in your structs to inherit IDs, tenancy, audit metadata,
 // status, and JSONB-backed free-form metadata and tags.
@@ -59,11 +55,13 @@ type CoreModel struct {
 //
 // Call this after defaults have been applied (e.g., after Create/Touch or
 // after GORM hooks). It returns nil if the model is valid.
-func (b *CoreModel) Validate() ValidationErrors {
-	var errs ValidationErrors
+func (b *CoreModel) Validate(loc string, code string) []verr.ValidationError {
+	var errs []verr.ValidationError
 
 	// local function helper creating and appending errors.
-	req := func(field, msg string) { errs = append(errs, verr.ValidationError{Field: field, Message: msg}) }
+	req := func(field, msg string) {
+		errs = append(errs, verr.ValidationError{Field: field, Message: msg, Loc: loc, Code: code})
+	}
 
 	if b.ID == uuid.Nil {
 		req("id", "required")

--- a/commonmodels/core/core_test.go
+++ b/commonmodels/core/core_test.go
@@ -43,7 +43,7 @@ func TestCoreModel_Validate_ID_is_required_and_uuid(t *testing.T) {
 		}
 	}
 	assert.True(t, exist)
-	assert.Equal(t, message, "required")
+	assert.Equal(t, message, "id is required.")
 
 	coreModel.ID = uuid.New()
 }
@@ -71,7 +71,7 @@ func TestCoreModel_Validate_TenantID_is_required_and_uuid(t *testing.T) {
 		}
 	}
 	assert.True(t, exist)
-	assert.Equal(t, message, "required")
+	assert.Equal(t, message, "tenant_id is required.")
 
 	coreModel.TenantID = uuid.New()
 }
@@ -99,7 +99,7 @@ func TestCoreModel_Validate_Name_is_requiredand_string(t *testing.T) {
 		}
 	}
 	assert.True(t, exist)
-	assert.Equal(t, message, "required")
+	assert.Equal(t, message, "name is required.")
 
 	coreModel.Name = "test"
 }
@@ -128,7 +128,7 @@ func TestCoreModel_Validate_CreatedBy_is_requiredand_string(t *testing.T) {
 	}
 	assert.True(t, exist)
 	allowed := map[string]struct{}{
-		"required": {}, "not a valid email format": {},
+		"created_by is required.": {}, "created_by must be a valid email address.": {},
 	}
 	_, ok := allowed[message]
 
@@ -161,7 +161,7 @@ func TestCoreModel_Validate_ModifiedBy_is_required_string(t *testing.T) {
 	}
 	assert.True(t, exist)
 	allowed := map[string]struct{}{
-		"required": {}, "not a valid email format": {},
+		"modified_by is required.": {}, "modified_by must be a valid email address.": {},
 	}
 	_, ok := allowed[message]
 
@@ -193,7 +193,7 @@ func TestCoreModel_Validate_CreatedAt_is_required_timestamp(t *testing.T) {
 		}
 	}
 	assert.True(t, exist)
-	assert.Equal(t, message, "required")
+	assert.Equal(t, message, "created_at is required.")
 
 	coreModel.CreatedAt = time.Now().UTC()
 }
@@ -221,7 +221,7 @@ func TestCoreModel_Validate_ModifiedAt_is_required_timestamp(t *testing.T) {
 		}
 	}
 	assert.True(t, exist)
-	assert.Equal(t, message, "required")
+	assert.Equal(t, message, "modified_at is required.")
 
 	coreModel.CreatedAt = time.Now().UTC()
 }

--- a/commonmodels/enum/errors/code.go
+++ b/commonmodels/enum/errors/code.go
@@ -1,0 +1,117 @@
+// Enums and function for generating ideomatic
+// responses accross service implementations.
+//
+// # Example
+//
+// HumanMessage(Required, "email")
+// "email is required."
+//
+// HumanMessageLocale("nb", InvalidEmailFormat, "E-post")
+// "E-post må være en gyldig e-postadresse."
+//
+// StatusFor(TooManyRequests) // 429
+package errors
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// -----------------------------------------------------------------------------
+// Machine-readable error codes
+// -----------------------------------------------------------------------------
+
+const (
+	Internal           = "internal_error"
+	Unauthorized       = "unauthorized"
+	Forbidden          = "forbidden"
+	NotFound           = "not_found"
+	Conflict           = "conflict"
+	BadRequest         = "bad_request"
+	ValidationFailed   = "validation_failed"
+	TooManyRequests    = "too_many_requests"
+	Required           = "required"
+	InvalidEmailFormat = "invalid_email_format"
+	InvalidJSONFormat  = "invalid_json_format"
+	InvalidStatus      = "invalid_status"
+)
+
+var messagesEN = map[string]string{
+	Internal:           "Something went wrong on our side. Please try again.",
+	Unauthorized:       "You need to sign in to continue.",
+	Forbidden:          "You don't have permission to perform this action.",
+	NotFound:           "The requested resource was not found.",
+	Conflict:           "The resource is in a conflicting state.",
+	BadRequest:         "Your request could not be understood.",
+	ValidationFailed:   "One or more fields failed validation.",
+	TooManyRequests:    "Too many requests. Please slow down.",
+	Required:           "%s is required.",
+	InvalidEmailFormat: "%s must be a valid email address.",
+	InvalidJSONFormat:  "Request body must be valid JSON.",
+	InvalidStatus:      "The provided status %s is invalid. It should be one of active, deleted, suspended, rejected, draft",
+}
+
+var messagesNB = map[string]string{ // Norwegian Bokmål (optional starter set)
+	Internal:           "Noe gikk galt hos oss. Prøv igjen.",
+	Unauthorized:       "Du må være innlogget for å fortsette.",
+	Forbidden:          "Du har ikke tilgang til denne handlingen.",
+	NotFound:           "Forespurt ressurs ble ikke funnet.",
+	Conflict:           "Ressursen er i konflikt.",
+	BadRequest:         "Forespørselen kunne ikke forstås.",
+	ValidationFailed:   "Ett eller flere felt feilet validering.",
+	TooManyRequests:    "For mange forespørsler. Vent litt.",
+	Required:           "%s er påkrevd.",
+	InvalidEmailFormat: "%s må være en gyldig e-postadresse.",
+	InvalidJSONFormat:  "Kroppen i forespørselen må være gyldig JSON.",
+	InvalidStatus:      "Oppgitt statusverdi er ugyldig.",
+}
+
+var catalogs = map[string]map[string]string{
+	"en": messagesEN,
+	"nb": messagesNB,
+}
+
+// HumanMessage returns a human-readable message for a machine code.
+// args are passed to fmt.Sprintf to fill placeholders like %s.
+func HumanMessage(code string, args ...any) string {
+	return HumanMessageLocale("en", code, args...)
+}
+
+// HumanMessageLocale lets you choose a locale (e.g., "en", "nb").
+func HumanMessageLocale(locale, code string, args ...any) string {
+	cat, ok := catalogs[locale]
+	if !ok {
+		cat = messagesEN
+	}
+	msg, ok := cat[code]
+	if !ok {
+		msg = messagesEN[Internal] // safe fallback
+	}
+	if len(args) > 0 {
+		return fmt.Sprintf(msg, args...)
+	}
+	return msg
+}
+
+// (Optional) map codes to HTTP status for consistent responses.
+var statusByCode = map[string]int{
+	Internal:           http.StatusInternalServerError,
+	Unauthorized:       http.StatusUnauthorized,
+	Forbidden:          http.StatusForbidden,
+	NotFound:           http.StatusNotFound,
+	Conflict:           http.StatusConflict,
+	BadRequest:         http.StatusBadRequest,
+	ValidationFailed:   http.StatusBadRequest,
+	TooManyRequests:    http.StatusTooManyRequests,
+	Required:           http.StatusBadRequest,
+	InvalidEmailFormat: http.StatusBadRequest,
+	InvalidJSONFormat:  http.StatusBadRequest,
+	InvalidStatus:      http.StatusBadRequest,
+}
+
+func StatusFor(code string) int {
+	if s, ok := statusByCode[code]; ok {
+		return s
+	}
+	return http.StatusInternalServerError
+}

--- a/commonmodels/enum/errors/code.go
+++ b/commonmodels/enum/errors/code.go
@@ -36,6 +36,10 @@ const (
 	InvalidStatus      = "invalid_status"
 )
 
+// -----------------------------------------------------------------------------
+// Human readable error messages EN
+// -----------------------------------------------------------------------------
+
 var messagesEN = map[string]string{
 	Internal:           "Something went wrong on our side. Please try again.",
 	Unauthorized:       "You need to sign in to continue.",
@@ -51,7 +55,11 @@ var messagesEN = map[string]string{
 	InvalidStatus:      "The provided status %s is invalid. It should be one of active, deleted, suspended, rejected, draft",
 }
 
-var messagesNB = map[string]string{ // Norwegian Bokmål (optional starter set)
+// -----------------------------------------------------------------------------
+// Human readable error messages NB
+// -----------------------------------------------------------------------------
+
+var messagesNB = map[string]string{
 	Internal:           "Noe gikk galt hos oss. Prøv igjen.",
 	Unauthorized:       "Du må være innlogget for å fortsette.",
 	Forbidden:          "Du har ikke tilgang til denne handlingen.",
@@ -66,6 +74,10 @@ var messagesNB = map[string]string{ // Norwegian Bokmål (optional starter set)
 	InvalidStatus:      "Oppgitt statusverdi er ugyldig.",
 }
 
+// -----------------------------------------------------------------------------
+// Message catalog
+// -----------------------------------------------------------------------------
+
 var catalogs = map[string]map[string]string{
 	"en": messagesEN,
 	"nb": messagesNB,
@@ -73,6 +85,18 @@ var catalogs = map[string]map[string]string{
 
 // HumanMessage returns a human-readable message for a machine code.
 // args are passed to fmt.Sprintf to fill placeholders like %s.
+//
+// # Example usage
+//
+// // local function helper creating and appending errors.
+//
+//	req := func(field, code string) {
+//		msg := errC.HumanMessageLocale(locale, code, field)
+//		errs = append(errs, verr.ValidationError{Field: field, Message: msg, Loc: loc, Code: code})
+//	}
+//
+// // Plain
+// msg := errC.HumanMessageLocale("en", errC.Required, "id")
 func HumanMessage(code string, args ...any) string {
 	return HumanMessageLocale("en", code, args...)
 }

--- a/commonmodels/http_error/http_error.go
+++ b/commonmodels/http_error/http_error.go
@@ -1,0 +1,181 @@
+// HTTP Error common
+//
+// JSON method of struct is omnitted
+// for the purpose of leaving commonmodels
+// as slim as possible.
+package httperror
+
+import (
+	"errors"
+	"net/http"
+
+	errC "github.com/grasp-labs/ds-go-commonmodels/v2/commonmodels/enum/errors"
+)
+
+// -----------------------------------------------------------------------------
+// HTTPError type
+// -----------------------------------------------------------------------------
+
+// HTTPError is the canonical error type returned to clients.
+//
+// Every error response has the shape:
+//
+//	{
+//	  "error": {
+//	    "code": "bad_request",
+//	    "message": "invalid payload",
+//	    "request_id": "3c640e85-75b3-4e0b-84c3-1b8427a64e23"
+//	  }
+//	}
+//
+// Fields:
+//   - Code:       a stable, machine-readable identifier.
+//   - Message:    a human-readable description safe to show clients.
+//   - RequestID:  always present, injected by middleware (never omitted).
+//
+// Internal-only:
+//   - cause:   the underlying Go error (not serialized).
+//   - status:  HTTP status code to return.
+type HTTPError struct {
+	Code      string `json:"code"`
+	Message   string `json:"message"`
+	RequestID string `json:"request_id"`
+
+	cause  error
+	status int
+}
+
+// Error implements the error interface.
+func (e *HTTPError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	return e.Message
+}
+
+// Unwrap enables errors.Is / errors.As to reach the underlying cause.
+func (e *HTTPError) Unwrap() error { return e.cause }
+
+// WithCause associates the underlying cause
+//
+// Examples:
+//
+//	return models.Internal(ctx, "").WithCause(err) // just wrap cause
+//
+// Notes:
+//   - The first argument remains the underlying cause used by errors.Is/As.
+func (e *HTTPError) WithCause(cause error) *HTTPError {
+	// Keep the original cause for errors.Is/As
+	if cause != nil {
+		e.cause = cause
+	}
+	return e
+}
+
+// Status returns the HTTP status code for this error.
+// If no explicit status is set, it falls back to defaults by Code.
+func (e *HTTPError) Status() int {
+	if e.status != 0 {
+		return e.status
+	}
+	switch e.Code {
+	case errC.BadRequest, errC.ValidationFailed:
+		return http.StatusBadRequest
+	case errC.Unauthorized:
+		return http.StatusUnauthorized
+	case errC.Forbidden:
+		return http.StatusForbidden
+	case errC.NotFound:
+		return http.StatusNotFound
+	case errC.Conflict:
+		return http.StatusConflict
+	case errC.TooManyRequests:
+		return http.StatusTooManyRequests
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+// Response returns (statusCode, *HttpError).
+//
+//	status, httpErr := err.Response(); return c.JSON(status, httpErr)
+func (e *HTTPError) Response() (int, *HTTPError) {
+	return e.Status(), e
+}
+
+// -----------------------------------------------------------------------------
+// Constructors
+// -----------------------------------------------------------------------------
+
+// NewHTTPError creates a new error with the given code, message, and status.
+// Normally you should use one of the convenience helpers (Internal, NotFound...).
+func NewHTTPError(requestID string, code string, message string, status int) *HTTPError {
+	return &HTTPError{
+		Code:      code,
+		Message:   message,
+		RequestID: requestID,
+		status:    status,
+	}
+}
+
+// Internal returns a 500 Internal Server Error.
+func Internal(requestID string, msg string) *HTTPError {
+	if msg == "" {
+		msg = "internal server error"
+	}
+	return NewHTTPError(requestID, errC.Internal, msg, http.StatusInternalServerError)
+}
+
+// Unauthorized returns a 401 Unauthorized error.
+func Unauthorized(requestID string, msg string) *HTTPError {
+	if msg == "" {
+		msg = "unauthorized"
+	}
+	return NewHTTPError(requestID, errC.Unauthorized, msg, http.StatusUnauthorized)
+}
+
+// Forbidden returns a 403 Forbidden error.
+func Forbidden(requestID string, msg string) *HTTPError {
+	if msg == "" {
+		msg = "forbidden"
+	}
+	return NewHTTPError(requestID, errC.Forbidden, msg, http.StatusForbidden)
+}
+
+// NotFound returns a 404 Not Found error.
+func NotFound(requestID string, msg string) *HTTPError {
+	if msg == "" {
+		msg = "not found"
+	}
+	return NewHTTPError(requestID, errC.NotFound, msg, http.StatusNotFound)
+}
+
+// Conflict returns a 409 Conflict error.
+func Conflict(requestID string, msg string) *HTTPError {
+	if msg == "" {
+		msg = "conflict"
+	}
+	return NewHTTPError(requestID, errC.Conflict, msg, http.StatusConflict)
+}
+
+// BadRequest returns a 400 Bad Request error.
+func BadRequest(requestID string, msg string) *HTTPError {
+	if msg == "" {
+		msg = "bad request"
+	}
+	return NewHTTPError(requestID, errC.BadRequest, msg, http.StatusBadRequest)
+}
+
+// FromError converts any error into an *HTTPError.
+//   - If the error is already *HTTPError, it is returned as-is.
+//   - Otherwise, it is wrapped as Internal with the original cause.
+func FromError(requestID string, err error) *HTTPError {
+	if err == nil {
+		return nil
+	}
+	var he *HTTPError
+	if errors.As(err, &he) {
+		return he
+	}
+	return Internal(requestID, "").WithCause(err)
+}

--- a/commonmodels/http_error/http_error_test.go
+++ b/commonmodels/http_error/http_error_test.go
@@ -1,0 +1,54 @@
+package httperror_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	he "github.com/grasp-labs/ds-go-commonmodels/v2/commonmodels/http_error"
+)
+
+func TestHttpError_NotFound(t *testing.T) {
+	requestID := uuid.MustParse("31ac4e2a-10a1-471d-ac7c-fd6ee13a526d").String()
+	httpErr := he.NotFound(requestID, "")
+	status := httpErr.Status()
+	if status != http.StatusNotFound {
+		t.Fatalf("expected %d, got %d", http.StatusNotFound, status)
+	}
+	jsonBytes, err := json.Marshal(httpErr)
+	if err != nil {
+		t.Fatalf("did not expect json marshal error, err: %v", err)
+	}
+	jsonStr := string(jsonBytes)
+	expected := `{"code":"not_found","message":"not found","request_id":"31ac4e2a-10a1-471d-ac7c-fd6ee13a526d"}`
+	if jsonStr != expected {
+		t.Fatalf("failed to marshal struct, got %s, expected %s", jsonStr, expected)
+	}
+
+	statusCode, hErr := httpErr.Response()
+	if statusCode != http.StatusNotFound {
+		t.Fatalf("expected %d, got %d", http.StatusNotFound, status)
+	}
+	expect := "not_found"
+	if hErr.Code != expect {
+		t.Fatalf("expected %s, got %s", expect, hErr.Code)
+	}
+	expect = "not found"
+	if hErr.Message != expect {
+		t.Fatalf("expected %s, got %s", expect, hErr.Code)
+	}
+	if _, err := uuid.Parse(hErr.RequestID); err != nil {
+		t.Fatalf("failed to parse, err: %v", err)
+	}
+
+	jsonBytes, err = json.Marshal(hErr)
+	if err != nil {
+		t.Fatalf("did not expect json marshal error, err: %v", err)
+	}
+	jsonStr = string(jsonBytes)
+	expected = `{"code":"not_found","message":"not found","request_id":"31ac4e2a-10a1-471d-ac7c-fd6ee13a526d"}`
+	if jsonStr != expected {
+		t.Fatalf("failed to marshal struct, got %s, expected %s", jsonStr, expected)
+	}
+}

--- a/commonmodels/validation_error/envelope.go
+++ b/commonmodels/validation_error/envelope.go
@@ -16,3 +16,5 @@ package validation_error
 type ErrorEnvelope struct {
 	Details []ValidationError `json:"details"`
 }
+
+//func (e *ErrorEnvelope) Marshal

--- a/commonmodels/validation_error/envelope.go
+++ b/commonmodels/validation_error/envelope.go
@@ -1,0 +1,18 @@
+package validation_error
+
+// ErrorEnvelope is used in order to wrap errors for response.
+// Example:
+//
+//	{
+//		"details": [
+//			{
+//				"field": "",
+//				"message": "",
+//				"loc": "",
+//				"code": "",
+//			}
+//		]
+//	}
+type ErrorEnvelope struct {
+	Details []ValidationError `json:"details"`
+}

--- a/commonmodels/validation_error/envelope_test.go
+++ b/commonmodels/validation_error/envelope_test.go
@@ -1,0 +1,63 @@
+package validation_error_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	ve "github.com/grasp-labs/ds-go-commonmodels/v2/commonmodels/validation_error"
+)
+
+func TestEnvelope_WrapValidationErrorAndMarshal(t *testing.T) {
+	var errors []ve.ValidationError
+
+	errors = append(errors, ve.ValidationError{
+		Field:   "foo",
+		Message: "bar",
+		Loc:     "header",
+		Code:    "",
+	})
+
+	details := ve.ErrorEnvelope{
+		Details: errors,
+	}
+	jsonBytes, err := json.Marshal(details)
+	if err != nil {
+		t.Fatalf("did not expect json marshal error, err: %v", err)
+	}
+	jsonStr := string(jsonBytes)
+	expected := `{"details":[{"field":"foo","message":"bar","loc":"header","code":""}]}`
+	if jsonStr != expected {
+		t.Fatalf("failed to marshal struct, got %s, expected %s", jsonStr, expected)
+	}
+}
+
+func TestEnvelope_MarshalNilDetails(t *testing.T) {
+
+	details := ve.ErrorEnvelope{
+		Details: nil,
+	}
+	jsonBytes, err := json.Marshal(details)
+	if err != nil {
+		t.Fatalf("did not expect json marshal error, err: %v", err)
+	}
+	jsonStr := string(jsonBytes)
+	expected := `{"details":null}`
+	if jsonStr != expected {
+		t.Fatalf("failed to marshal struct, got %s, expected %s", jsonStr, expected)
+	}
+}
+
+func TestEnvelope_MarshalEmptySlice(t *testing.T) {
+	details := ve.ErrorEnvelope{
+		Details: []ve.ValidationError{},
+	}
+	jsonBytes, err := json.Marshal(details)
+	if err != nil {
+		t.Fatalf("did not expect json marshal error, err: %v", err)
+	}
+	jsonStr := string(jsonBytes)
+	expected := `{"details":[]}`
+	if jsonStr != expected {
+		t.Fatalf("failed to marshal struct, got %s, expected %s", jsonStr, expected)
+	}
+}

--- a/commonmodels/validation_error/validation_error.go
+++ b/commonmodels/validation_error/validation_error.go
@@ -3,9 +3,10 @@ package validation_error
 type Location string
 
 const (
-	Header Location = "header"
-	Query  Location = "query"
 	Body   Location = "body"
+	Header Location = "header"
+	Path   Location = "path"
+	Query  Location = "query"
 )
 
 // The ValidationError is a common model used to
@@ -38,7 +39,8 @@ type ValidationError struct {
 }
 
 var ValidLocations = map[Location]struct{}{
-	Header: {},
-	Query:  {},
 	Body:   {},
+	Header: {},
+	Path:   {},
+	Query:  {},
 }

--- a/commonmodels/validation_error/validation_error.go
+++ b/commonmodels/validation_error/validation_error.go
@@ -3,10 +3,33 @@ package validation_error
 type Location string
 
 const (
-	Query Location = "query"
-	Body  Location = "body"
+	Header Location = "header"
+	Query  Location = "query"
+	Body   Location = "body"
 )
 
+// The ValidationError is a common model used to
+// structure error responses across our internal apis.
+//
+// Field: The path to the exception.
+//
+//	Example: data.owner.id
+//
+// Message: Human readable message to decipher what happened.
+//
+//	Example: Missing owner id
+//
+// Loc: Location of where the field resides
+//
+//	Example: body
+//
+// Code: The error code.
+//
+//	Example: required.missing
+//	Example: length.min / length.max
+//	Example: type.integer
+//
+// See ErrorEnvelope for returning validation errors to client.
 type ValidationError struct {
 	Field   string `json:"field"`
 	Message string `json:"message"`
@@ -15,6 +38,7 @@ type ValidationError struct {
 }
 
 var ValidLocations = map[Location]struct{}{
-	Query: {},
-	Body:  {},
+	Header: {},
+	Query:  {},
+	Body:   {},
 }

--- a/commonmodels/validation_error/validation_error_test.go
+++ b/commonmodels/validation_error/validation_error_test.go
@@ -8,12 +8,24 @@ import (
 
 // Test for validating Locations.
 func TestValidationError_ValidLocations(t *testing.T) {
-	locs := []string{"query", "body"}
+	locs := []string{"query", "body", "path", "header"}
 
 	for _, l := range locs {
 		_, ok := ve.ValidLocations[ve.Location(l)]
 		if !ok {
 			t.Fatalf("expected %s to be ok, got error", l)
+		}
+	}
+}
+
+// Test for validating Locations.
+func TestValidationError_InvalidLocations(t *testing.T) {
+	locs := []string{"not", "NOT", "PATH"}
+
+	for _, l := range locs {
+		_, ok := ve.ValidLocations[ve.Location(l)]
+		if ok {
+			t.Fatalf("expected %s not to be ok, got error", l)
 		}
 	}
 }

--- a/commonmodels/validators/email/email.go
+++ b/commonmodels/validators/email/email.go
@@ -1,13 +1,11 @@
 package email
 
 import (
-	"fmt"
 	"net/mail"
 )
 
 func IsEmailFormat(s string) bool {
 	a, err := mail.ParseAddress(s)
-	fmt.Printf("Failed to parse email %s, err: %v", s, err)
 	if err != nil {
 		return false
 	}

--- a/commonmodels/validators/json_schema/json_schema.go
+++ b/commonmodels/validators/json_schema/json_schema.go
@@ -32,7 +32,7 @@ const NoneFieldError = "none_field_error"
 //	if errs := json_schema.ValidateAgainstSchema(b, EventJSONSchema); len(errs) > 0 {
 //	    // surface errs to the user as your API's standard validation errors
 //	}
-func ValidateAgainstSchema(docBytes []byte, jsonSchema []byte) []verr.ValidationError {
+func ValidateAgainstSchema(docBytes []byte, jsonSchema []byte, loc string, code string) []verr.ValidationError {
 	schemaLoader := gojsonschema.NewBytesLoader(jsonSchema)
 	docLoader := gojsonschema.NewBytesLoader(docBytes)
 
@@ -41,6 +41,8 @@ func ValidateAgainstSchema(docBytes []byte, jsonSchema []byte) []verr.Validation
 		return []verr.ValidationError{{
 			Field:   NoneFieldError,
 			Message: "schema validator error: " + err.Error(),
+			Loc:     loc,
+			Code:    code,
 		}}
 	}
 
@@ -58,6 +60,8 @@ func ValidateAgainstSchema(docBytes []byte, jsonSchema []byte) []verr.Validation
 		errs = append(errs, verr.ValidationError{
 			Field:   field,
 			Message: fmt.Sprintf("(%s): %s", kw, issue.Description()),
+			Loc:     loc,
+			Code:    code,
 		})
 	}
 	return errs

--- a/commonmodels/validators/json_schema/json_schema.go
+++ b/commonmodels/validators/json_schema/json_schema.go
@@ -32,7 +32,7 @@ const NoneFieldError = "none_field_error"
 //	if errs := json_schema.ValidateAgainstSchema(b, EventJSONSchema); len(errs) > 0 {
 //	    // surface errs to the user as your API's standard validation errors
 //	}
-func ValidateAgainstSchema(docBytes []byte, jsonSchema []byte, loc string, code string) []verr.ValidationError {
+func ValidateAgainstSchema(docBytes []byte, jsonSchema []byte) []verr.ValidationError {
 	schemaLoader := gojsonschema.NewBytesLoader(jsonSchema)
 	docLoader := gojsonschema.NewBytesLoader(docBytes)
 
@@ -41,8 +41,6 @@ func ValidateAgainstSchema(docBytes []byte, jsonSchema []byte, loc string, code 
 		return []verr.ValidationError{{
 			Field:   NoneFieldError,
 			Message: "schema validator error: " + err.Error(),
-			Loc:     loc,
-			Code:    code,
 		}}
 	}
 
@@ -60,8 +58,6 @@ func ValidateAgainstSchema(docBytes []byte, jsonSchema []byte, loc string, code 
 		errs = append(errs, verr.ValidationError{
 			Field:   field,
 			Message: fmt.Sprintf("(%s): %s", kw, issue.Description()),
-			Loc:     loc,
-			Code:    code,
 		})
 	}
 	return errs


### PR DESCRIPTION
This PR is doing the following:
 - Change return type of Core.Validate from internal type to ValidationError
 - Added envelope.go to wrap validation errors for client
 - Added docs to further explain how to use fields in ValidationError