### PR TITLE
feat(json_schema): add location and code fields to validation errors

### DIFF
--- a/commonmodels/validators/json_schema/json_schema.go
+++ b/commonmodels/validators/json_schema/json_schema.go
@@ -41,6 +41,8 @@ func ValidateAgainstSchema(docBytes []byte, jsonSchema []byte) []verr.Validation
 		return []verr.ValidationError{{
 			Field:   NoneFieldError,
 			Message: "schema validator error: " + err.Error(),
+			Loc:     "json_schema_validator",
+			Code:    "validator_error",
 		}}
 	}
 
@@ -58,6 +60,8 @@ func ValidateAgainstSchema(docBytes []byte, jsonSchema []byte) []verr.Validation
 		errs = append(errs, verr.ValidationError{
 			Field:   field,
 			Message: fmt.Sprintf("(%s): %s", kw, issue.Description()),
+			Loc:     "json_schema_validation",
+			Code:    kw,
 		})
 	}
 	return errs

--- a/commonmodels/validators/json_schema/json_schema.go
+++ b/commonmodels/validators/json_schema/json_schema.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"strings"
 
+	ecode "github.com/grasp-labs/ds-go-commonmodels/v3/commonmodels/enum/errors"
 	verr "github.com/grasp-labs/ds-go-commonmodels/v3/commonmodels/validation_error"
 	"github.com/xeipuuv/gojsonschema"
 )
@@ -41,8 +42,8 @@ func ValidateAgainstSchema(docBytes []byte, jsonSchema []byte) []verr.Validation
 		return []verr.ValidationError{{
 			Field:   NoneFieldError,
 			Message: "schema validator error: " + err.Error(),
-			Loc:     "json_schema_validator",
-			Code:    "validator_error",
+			Loc:     string(verr.Body),
+			Code:    ecode.ValidationFailed,
 		}}
 	}
 
@@ -60,8 +61,8 @@ func ValidateAgainstSchema(docBytes []byte, jsonSchema []byte) []verr.Validation
 		errs = append(errs, verr.ValidationError{
 			Field:   field,
 			Message: fmt.Sprintf("(%s): %s", kw, issue.Description()),
-			Loc:     "json_schema_validation",
-			Code:    kw,
+			Loc:     string(verr.Body),
+			Code:    ecode.ValidationFailed,
 		})
 	}
 	return errs

--- a/commonmodels/validators/json_schema/json_schema_event_test.go
+++ b/commonmodels/validators/json_schema/json_schema_event_test.go
@@ -204,7 +204,6 @@ func TestEvent_JSONSchema_Failures(t *testing.T) {
 				if strings.Contains(e.Message, "pattern") || strings.Contains(e.Message, "format") {
 					foundM++
 				}
-				// Assert Loc and Code for all errors
 				if e.Loc != string(verr.Body) {
 					t.Errorf("Expected Loc to be %q, got %q", string(verr.Body), e.Loc)
 				}

--- a/commonmodels/validators/json_schema/json_schema_event_test.go
+++ b/commonmodels/validators/json_schema/json_schema_event_test.go
@@ -143,7 +143,7 @@ func TestEvent_JSONSchema_Failures(t *testing.T) {
 		foundF := 0
 		foundM := 0
 		for _, e := range validationErrors {
-			if e.Field == "none_field_error" {
+			if e.Field == js.NoneFieldError {
 				foundF++
 				if strings.Contains(e.Message, "anyOf") || strings.Contains(e.Message, "required") {
 					foundM++

--- a/commonmodels/validators/json_schema/json_schema_event_test.go
+++ b/commonmodels/validators/json_schema/json_schema_event_test.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/google/uuid"
 
+	ecode "github.com/grasp-labs/ds-go-commonmodels/v3/commonmodels/enum/errors"
 	events "github.com/grasp-labs/ds-go-commonmodels/v3/commonmodels/kafka"
 	"github.com/grasp-labs/ds-go-commonmodels/v3/commonmodels/types"
+	verr "github.com/grasp-labs/ds-go-commonmodels/v3/commonmodels/validation_error"
 	js "github.com/grasp-labs/ds-go-commonmodels/v3/commonmodels/validators/json_schema"
 )
 
@@ -146,6 +148,13 @@ func TestEvent_JSONSchema_Failures(t *testing.T) {
 				if strings.Contains(e.Message, "anyOf") || strings.Contains(e.Message, "required") {
 					foundM++
 				}
+				// Assert Loc and Code are set correctly
+				if e.Loc != string(verr.Body) {
+					t.Errorf("Expected Loc to be %q, got %q", string(verr.Body), e.Loc)
+				}
+				if e.Code != ecode.ValidationFailed {
+					t.Errorf("Expected Code to be %q, got %q", ecode.ValidationFailed, e.Code)
+				}
 			}
 
 		}
@@ -168,6 +177,13 @@ func TestEvent_JSONSchema_Failures(t *testing.T) {
 				if e.Message != "(minProperties): Must have at least 1 properties" {
 					t.Fatalf("Expected message '(minProperties): Must have at least 1 properties', got %s", e.Message)
 				}
+				// Assert Loc and Code are set correctly
+				if e.Loc != string(verr.Body) {
+					t.Errorf("Expected Loc to be %q, got %q", string(verr.Body), e.Loc)
+				}
+				if e.Code != ecode.ValidationFailed {
+					t.Errorf("Expected Code to be %q, got %q", ecode.ValidationFailed, e.Code)
+				}
 			}
 		}
 	})
@@ -188,6 +204,13 @@ func TestEvent_JSONSchema_Failures(t *testing.T) {
 				if strings.Contains(e.Message, "pattern") || strings.Contains(e.Message, "format") {
 					foundM++
 				}
+				// Assert Loc and Code for all errors
+				if e.Loc != string(verr.Body) {
+					t.Errorf("Expected Loc to be %q, got %q", string(verr.Body), e.Loc)
+				}
+				if e.Code != ecode.ValidationFailed {
+					t.Errorf("Expected Code to be %q, got %q", ecode.ValidationFailed, e.Code)
+				}
 			}
 
 			if e.Field == "affected_entity_uri" {
@@ -195,12 +218,26 @@ func TestEvent_JSONSchema_Failures(t *testing.T) {
 				if strings.Contains(e.Message, "format") {
 					foundM++
 				}
+				// Assert Loc and Code for all errors
+				if e.Loc != string(verr.Body) {
+					t.Errorf("Expected Loc to be %q, got %q", string(verr.Body), e.Loc)
+				}
+				if e.Code != ecode.ValidationFailed {
+					t.Errorf("Expected Code to be %q, got %q", ecode.ValidationFailed, e.Code)
+				}
 			}
 
 			if e.Field == "event_source_uri" {
 				foundF++
 				if strings.Contains(e.Message, "format") {
 					foundM++
+				}
+				// Assert Loc and Code for all errors
+				if e.Loc != string(verr.Body) {
+					t.Errorf("Expected Loc to be %q, got %q", string(verr.Body), e.Loc)
+				}
+				if e.Code != ecode.ValidationFailed {
+					t.Errorf("Expected Code to be %q, got %q", ecode.ValidationFailed, e.Code)
 				}
 			}
 
@@ -224,6 +261,13 @@ func TestEvent_JSONSchema_Failures(t *testing.T) {
 				if strings.Contains(e.Message, "pattern") || strings.Contains(e.Message, "format") {
 					foundM++
 				}
+				// Assert Loc and Code for all errors
+				if e.Loc != string(verr.Body) {
+					t.Errorf("Expected Loc to be %q, got %q", string(verr.Body), e.Loc)
+				}
+				if e.Code != ecode.ValidationFailed {
+					t.Errorf("Expected Code to be %q, got %q", ecode.ValidationFailed, e.Code)
+				}
 			}
 
 			if e.Field == "md5_hash" {
@@ -231,7 +275,40 @@ func TestEvent_JSONSchema_Failures(t *testing.T) {
 				if strings.Contains(e.Message, "format") {
 					foundM++
 				}
+				// Assert Loc and Code for all errors
+				if e.Loc != string(verr.Body) {
+					t.Errorf("Expected Loc to be %q, got %q", string(verr.Body), e.Loc)
+				}
+				if e.Code != ecode.ValidationFailed {
+					t.Errorf("Expected Code to be %q, got %q", ecode.ValidationFailed, e.Code)
+				}
 			}
+		}
+	})
+
+	t.Run("validator_error", func(t *testing.T) {
+		// Test with an invalid schema to trigger the validator error path
+		invalidSchema := []byte(`{invalid json`)
+		ev := newValidEvent()
+		validationErrors := js.ValidateAgainstSchema(marshal(t, ev), invalidSchema)
+
+		if len(validationErrors) != 1 {
+			t.Fatalf("Expected exactly one validation error, got %d", len(validationErrors))
+		}
+
+		e := validationErrors[0]
+		// Validator errors should have Field = NoneFieldError and proper Loc and Code
+		if e.Field != js.NoneFieldError {
+			t.Errorf("Expected Field to be %q, got %q", js.NoneFieldError, e.Field)
+		}
+		if e.Loc != string(verr.Body) {
+			t.Errorf("Expected Loc to be %q, got %q", string(verr.Body), e.Loc)
+		}
+		if e.Code != ecode.ValidationFailed {
+			t.Errorf("Expected Code to be %q, got %q", ecode.ValidationFailed, e.Code)
+		}
+		if !strings.Contains(e.Message, "schema validator error") {
+			t.Errorf("Expected message to contain 'schema validator error', got %q", e.Message)
 		}
 	})
 }


### PR DESCRIPTION
*Issue #, if available:*
7096
*Description of changes:*
add loc and code to validate against schema function that's used by ingress. This is to resolve missing values in ingress error messages. ds-go-commonmodels import needs updating.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.